### PR TITLE
A minor documentation update in readme to build on Windows x64

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ vcpkg install cpr
 vcpkg integrate install
 ```  
 
+####Windows x64
+Most Windows machines are x64 now, but by default vcpkg uses x86 triplets (and installs x86 dependencies, if other is not set on your machine).
+If you are not using Virtual Machine, then you need to make sure you have installed appropriate dependencies:
+```bash
+./vcpkg install nlohmann-json:x64-windows
+./vcpkg install cpr:x64-windows
+```  
+
 * Clone the repository  
 ```bash
 git clone https://github.com/deni2312/Telegram-Bot-Api-Cpp.git


### PR DESCRIPTION
While following the documentation on my Windows machine I have found that we need to specify x64 triplets when installing vcpkg dependencies. Little goolging solves the problem. But I feel it might worth to keep in the documentation.